### PR TITLE
Use converted files to detect chapter timestamps

### DIFF
--- a/src/library/M4bTool/Command/MergeCommand.php
+++ b/src/library/M4bTool/Command/MergeCommand.php
@@ -411,7 +411,7 @@ class MergeCommand extends AbstractConversionCommand implements MetaReaderInterf
         $autoSplitMilliSeconds = (int)$this->input->getOption(static::OPTION_AUTO_SPLIT_SECONDS) * 1000;
 
         $chapterBuilder = new ChapterTitleBuilder($this);
-        $this->chapters = $chapterBuilder->buildChapters($this->filesToConvert, $autoSplitMilliSeconds);
+        $this->chapters = $chapterBuilder->buildChapters($this->filesToMerge, $autoSplitMilliSeconds);
     }
 
     private function replaceChaptersWithMusicBrainz()


### PR DESCRIPTION
Currently the tool uses source files for chapter timestamps, which leads to broken chapters when mp3 files have invalid metadata:

```
$ ffmpeg -i file.mp3 -f ffmetadata -
  Duration: 00:18:47.09, start: 0.000000, bitrate: 64 kb/s

$ ffmpeg -i file.mp3 -f null -
  Duration: 00:18:47.09, start: 0.000000, bitrate: 64 kb/s
size=N/A time=00:18:52.38 bitrate=N/A speed= 709x
```

This PR switches from source files to converted files when detecting chapter timestamps.