### PR TITLE
Properly set description meta tags

### DIFF
--- a/src/library/M4bTool/Audio/Tag.php
+++ b/src/library/M4bTool/Audio/Tag.php
@@ -32,6 +32,8 @@ class Tag
     public $cover;
     //-m, -description STR  Set the short description
     public $description;
+    //-l, -longdesc    STR  Set the long description
+    public $longDescription;
     //-c, -comment     STR  Set a general comment
     public $comment;
 

--- a/src/library/M4bTool/Audio/Tag.php
+++ b/src/library/M4bTool/Audio/Tag.php
@@ -11,6 +11,8 @@ namespace M4bTool\Audio;
 
 class Tag
 {
+    const MP4_STIK_AUDIOBOOK = 2;
+
     public $encoder = "m4b-tool";
     //-s, -song        STR  Set the title of the song, movie, tv show,...
     public $title;

--- a/src/library/M4bTool/Command/AbstractConversionCommand.php
+++ b/src/library/M4bTool/Command/AbstractConversionCommand.php
@@ -25,6 +25,8 @@ class AbstractConversionCommand extends AbstractCommand
     protected $optAudioCodec;
     protected $optAdjustBitrateForIpod;
 
+    protected $longDescription;
+
 
     protected function configure()
     {
@@ -157,6 +159,7 @@ Codecs:
             $this->appendParameterToCommand($command, "-genre", $tag->genre);
             $this->appendParameterToCommand($command, "-writer", $tag->writer);
             $this->appendParameterToCommand($command, "-description", $tag->description);
+            $this->appendParameterToCommand($command, "-longdesc", $tag->longDescription);
             $this->appendParameterToCommand($command, "-albumartist", $tag->albumArtist);
             $this->appendParameterToCommand($command, "-year", $tag->year);
             $this->appendParameterToCommand($command, "-album", $tag->album);
@@ -203,6 +206,7 @@ Codecs:
         $tag->year = $this->input->getOption("year");
         $tag->cover = $this->input->getOption("cover");
         $tag->description = $this->input->getOption("description");
+        $tag->longDescription = $this->longDescription;
 
         $tag->comment = $this->input->getOption("comment");
         $tag->copyright = $this->input->getOption("copyright");

--- a/src/library/M4bTool/Command/AbstractConversionCommand.php
+++ b/src/library/M4bTool/Command/AbstractConversionCommand.php
@@ -166,6 +166,7 @@ Codecs:
             $this->appendParameterToCommand($command, "-comment", $tag->comment);
             $this->appendParameterToCommand($command, "-copyright", $tag->copyright);
             $this->appendParameterToCommand($command, "-encodedby", $tag->encodedBy);
+            $this->appendParameterToCommand($command, "-type", Tag::MP4_STIK_AUDIOBOOK);
 
 
             if (count($command) > 1) {

--- a/src/library/M4bTool/Command/AbstractConversionCommand.php
+++ b/src/library/M4bTool/Command/AbstractConversionCommand.php
@@ -202,6 +202,7 @@ Codecs:
         $tag->albumArtist = $this->input->getOption("albumartist");
         $tag->year = $this->input->getOption("year");
         $tag->cover = $this->input->getOption("cover");
+        $tag->description = $this->input->getOption("description");
 
         $tag->comment = $this->input->getOption("comment");
         $tag->copyright = $this->input->getOption("copyright");
@@ -257,7 +258,7 @@ Codecs:
             $command[] = 'genre=' . $tag->genre;
         }
 
-        if ($tag->copyright) {
+        if ($tag->description) {
             $command[] = '-metadata';
             $command[] = 'description=' . $tag->description;
         }

--- a/src/library/M4bTool/Command/MergeCommand.php
+++ b/src/library/M4bTool/Command/MergeCommand.php
@@ -182,6 +182,7 @@ class MergeCommand extends AbstractConversionCommand implements MetaReaderInterf
         $this->setOptionIfUndefined("year", $metaData->getProperty("date"));
         $this->setOptionIfUndefined("genre", $metaData->getProperty("genre"));
         $this->setOptionIfUndefined("writer", $metaData->getProperty("writer"));
+        $this->setOptionIfUndefined("description", $metaData->getProperty("description"));
     }
 
     private function setOptionIfUndefined($optionName, $optionValue)
@@ -386,7 +387,7 @@ class MergeCommand extends AbstractConversionCommand implements MetaReaderInterf
     }
 
     private function lookupAndAddDescription() {
-        if ($this->argInputFile->isDir() && $this->input->getOption("description") != "") {
+        if ($this->argInputFile->isDir() && !$this->input->getOption("description")) {
             $this->output->writeln("searching for description.txt in ".$this->argInputFile);
 
             $autoDescriptionFile = new SplFileInfo($this->argInputFile . DIRECTORY_SEPARATOR . "description.txt");

--- a/src/library/M4bTool/Command/MergeCommand.php
+++ b/src/library/M4bTool/Command/MergeCommand.php
@@ -183,6 +183,10 @@ class MergeCommand extends AbstractConversionCommand implements MetaReaderInterf
         $this->setOptionIfUndefined("genre", $metaData->getProperty("genre"));
         $this->setOptionIfUndefined("writer", $metaData->getProperty("writer"));
         $this->setOptionIfUndefined("description", $metaData->getProperty("description"));
+
+        if (!$this->longDescription) {
+            $this->longDescription = $metaData->getProperty("longdesc");
+        }
     }
 
     private function setOptionIfUndefined($optionName, $optionValue)
@@ -394,7 +398,8 @@ class MergeCommand extends AbstractConversionCommand implements MetaReaderInterf
             if ($autoDescriptionFile->isFile() && $autoDescriptionFile->getSize() < 1024*1024) {
                 $this->output->writeln("using description file ".$autoDescriptionFile);
                 $description = @file_get_contents($autoDescriptionFile);
-                if($description) {
+                if($description && strlen($description) > 255) {
+                    $this->longDescription = trim($description);
                     $description = mb_substr(trim($description), 0, 255);
                 }
                 $this->setOptionIfUndefined("description", $description);


### PR DESCRIPTION
Changes in this PR:

* Description is set for m4b files (`$tag->description` was not initialized before, and so it was always empty)
* `description.txt` would be only loaded if the description is set via arguments. Now it will only be loaded if the argument is missing
* Description meta tag is being pulled out of source files
* Added long description (synopsis) support. While the description is limited to 255 chars, the long description is not. It is not controlled via arguments but set to the untruncated description if the latter is longer than 255 chars.
* Not really related to descriptions, but media type is set to 2 (audiobook) in m4b metadata.