### PR TITLE
WIP: Complete overhaul of dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM FROM d2dyno/ffmpeg-docker:alpine AS ffmpeg
+FROM d2dyno/ffmpeg-docker:alpine AS ffmpeg
 
 FROM alpine:3.9 AS build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,117 +1,25 @@
-FROM alpine:3.9.2
+FROM d2dyno/ffmpeg-docker AS ffmpeg
 
-ENV WORKDIR /mnt
+FROM ubuntu:bionic
+
 ARG M4B_TOOL_DOWNLOAD_LINK="https://github.com/sandreas/m4b-tool/releases/latest/download/m4b-tool.phar"
-ARG FFMPEG_VERSION=4.1
-ARG PREFIX=/ffmpeg_build
 
-RUN \
-echo "---- INSTALL BUILD DEPENDENCIES ----" \
-    && apk add --no-cache --update --upgrade --virtual=build-dependencies \
-    autoconf \
-    automake \
-    boost-dev \
-    build-base \
-    gcc \
-    lame-dev \
-    libogg-dev \
-    yasm \
-    nasm \
-    yasm-dev \
-    zlib-dev \
-    freetype-dev \
-    libogg-dev \
-    libtheora-dev \
-    libvorbis-dev \
-    openssl-dev \
-    opus-dev \
-    git \
-    tar \
-    wget && \
-echo "---- INSTALL RUNTIME PACKAGES ----" \
-    && apk add --no-cache --update --upgrade bzip2 \
-    ca-certificates \
-    coreutils \
-    curl \
-    file \
-    libtool \
-    freetype \
-    lame \
-    libogg \
-    libvpx \
-    libvorbis \
-    libtheora \
-    libvorbis \
-    openssl \
-    opus \
-    pcre \
-    php7-cli \
-    php7-dom \
-    php7-intl \
-    php7-json \
-    php7-xml \
-    php7-curl \
-    php7-mbstring \
-    php7-simplexml \
-    php7-phar \
-    pkgconf \
-    pkgconfig \
-    && echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories \
-    && apk add --update fdk-aac-dev \
-    && echo "date.timezone = UTC" >> /etc/php7/php.ini && \
-echo "---- COMPILE FFMPEG ----" \
-    && cd /tmp/ \
-    && wget http://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.gz \
-    && tar zxf ffmpeg-${FFMPEG_VERSION}.tar.gz \
-    && rm ffmpeg-${FFMPEG_VERSION}.tar.gz \
-    && cd /tmp/ffmpeg-${FFMPEG_VERSION} \
-    && ./configure \
-    --enable-version3 \
-    --enable-gpl \
-    --enable-nonfree \
-    --enable-small \
-    --enable-libmp3lame \
-    --enable-libtheora \
-    --enable-libvorbis \
-    --enable-libopus \
-    --enable-libfdk_aac \
-    --enable-avresample \
-    --enable-libfreetype \
-    --enable-openssl \
-    --disable-debug \
-    --disable-doc \
-    --disable-ffplay \
-    --prefix="/tmp${PREFIX}"  \
-    --extra-cflags="-I/tmp${PREFIX}/include" \
-    --extra-ldflags="-L/tmp${PREFIX}/lib" \
-    --extra-libs="-lpthread -lm" \
-    --bindir="/usr/local/bin/"  \
-    && make && make install && make distclean && hash -r && rm -rf /tmp/* && \
-echo "---- COMPILE SANDREAS MP4V2 ----" \
-    && cd /tmp/ \
-    && wget https://github.com/sandreas/mp4v2/archive/master.zip \
-    && unzip master.zip \
-    && rm master.zip \
-    && cd mp4v2-master \
-    && ./configure && make && make install && make distclean && rm -rf /tmp/* && \
-echo "---- COMPILE FDKAAC ----" \
-    && cd /tmp/ \
-    && wget https://github.com/nu774/fdkaac/archive/1.0.0.tar.gz \
-    && tar xzf 1.0.0.tar.gz \
-    && rm 1.0.0.tar.gz \
-    && cd fdkaac-1.0.0 \
-    && autoreconf -i && ./configure && make && make install && rm -rf /tmp/* && \
-echo "---- REMOVE BUILD DEPENDENCIES ----" \
-    && apk del --purge build-dependencies
+RUN apt-get update && \
+  apt-get install -y \
+  mp4v2-utils \
+  php-cli \
+  php7.2-common \
+  php7.2-mbstring \
+  wget && \
+  rm -rf /var/lib/apt/lists/*
 
-# workaround to copy a local m4b-tool.phar IF it exists
-ADD ./Dockerfile ./dist/m4b-tool.phar* /tmp/
-RUN echo "---- INSTALL M4B-TOOL ----" \
-    && if [ ! -f /tmp/m4b-tool.phar ]; then wget "${M4B_TOOL_DOWNLOAD_LINK}" -O /tmp/m4b-tool.phar ; fi \
-    && mv /tmp/m4b-tool.phar /usr/local/bin/m4b-tool \
-    && chmod +x /usr/local/bin/m4b-tool
+RUN wget "$M4B_TOOL_DOWNLOAD_LINK" -O /usr/local/bin/m4b-tool && chmod +x /usr/local/bin/m4b-tool
+
+RUN apt-get remove -y wget
+
+COPY --from=ffmpeg /app/ffmpeg /usr/bin
+COPY --from=ffmpeg /app/ffprobe /usr/bin
 
 WORKDIR ${WORKDIR}
 CMD ["list"]
 ENTRYPOINT ["m4b-tool"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,9 @@ FROM alpine:3.9
 ARG M4B_TOOL_DOWNLOAD_LINK="https://github.com/sandreas/m4b-tool/releases/latest/download/m4b-tool.phar"
 
 RUN apk add --update \
-  php-cli \
-  php7-common \
+  php7-cli \
   php7-mbstring \
+  php7-phar \
   wget
   
 RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ARG M4B_TOOL_DOWNLOAD_LINK="https://github.com/sandreas/m4b-tool/releases/latest
 
 RUN apk add --update \
   php7-cli \
+  php7-json \
   php7-mbstring \
   php7-phar \
   wget

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,51 @@
-FROM d2dyno/ffmpeg-docker AS ffmpeg
+FROM FROM d2dyno/ffmpeg-docker:alpine AS ffmpeg
 
-FROM ubuntu:bionic
+FROM alpine:3.9 AS build
+
+RUN echo "---- INSTALL BUILD DEPENDENCIES ----" \
+    && apk add --no-cache --update --upgrade --virtual=build-dependencies \
+    autoconf \
+    automake \
+    boost-dev \
+    build-base \
+    gcc \
+    git \
+    tar \
+    wget
+    
+RUN echo "---- COMPILE SANDREAS MP4V2 ----" \
+  && cd /tmp/ \
+  && wget https://github.com/sandreas/mp4v2/archive/master.zip \
+  && unzip master.zip \
+  && rm master.zip \
+  && cd mp4v2-master \
+  && ./configure && \
+  make && \
+  make install
+
+FROM alpine:3.9
 
 ARG M4B_TOOL_DOWNLOAD_LINK="https://github.com/sandreas/m4b-tool/releases/latest/download/m4b-tool.phar"
 
-RUN apt-get update && \
-  apt-get install -y \
-  mp4v2-utils \
+RUN apk add --update \
   php-cli \
-  php7.2-common \
-  php7.2-mbstring \
-  wget && \
-  rm -rf /var/lib/apt/lists/*
+  php7-common \
+  php7-mbstring \
+  wget
+  
+RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
+  apk add --update fdk-aac-dev && \
+  rm -rf /var/cache/apk/* /tmp/*
 
 RUN wget "$M4B_TOOL_DOWNLOAD_LINK" -O /usr/local/bin/m4b-tool && chmod +x /usr/local/bin/m4b-tool
 
-RUN apt-get remove -y wget
+RUN apk del wget
 
-COPY --from=ffmpeg /app/ffmpeg /usr/bin
-COPY --from=ffmpeg /app/ffprobe /usr/bin
+COPY --from=build /usr/local/bin/mp4* /usr/local/bin/
+
+COPY --from=ffmpeg /app/ffmpeg /usr/local/bin
+
+COPY --from=ffmpeg /app/ffprobe /usr/local/bin
 
 WORKDIR ${WORKDIR}
 CMD ["list"]


### PR DESCRIPTION
There were a few issues here:
- Build was done inside the final image, rather than using multi-stage, to run build outside of the final image.
- fdk-aac was not the official source. (https://github.com/mstorsjo/fdk-aac is the official)
- FFMPEG was compiled non-statically, which meant a lot of packages had to be installed to the image. This version will grab all it needs from my ffmpeg docker, removing virtually all dependencies
- For simplicity, this is built with Ubuntu 18.04.