### PR TITLE
musicbrainz-id: pass estimateDuration the correct file path

### DIFF
--- a/src/library/Command/MergeCommand.php
+++ b/src/library/Command/MergeCommand.php
@@ -881,7 +881,7 @@ class MergeCommand extends AbstractConversionCommand
             $mbChapterParser = new MusicBrainzChapterParser($mbId);
             $mbChapterParser->setCacheAdapter($this->cacheAdapter);
 
-            $tagImprover->add(new ChaptersFromMusicBrainz($this->chapterMarker, $this->chapterHandler, $mbChapterParser, $this->metaHandler->estimateDuration($this->outputFile)));
+            $tagImprover->add(new ChaptersFromMusicBrainz($this->chapterMarker, $this->chapterHandler, $mbChapterParser, $this->metaHandler->estimateDuration($outputTmpFile)));
         }
 
 


### PR DESCRIPTION
The outputFile is not created by the time this code is executed. The final file has been created, but in the tmp directory, so that path music be passed to this function at this time.

I didn't see any existing tests for this functionality.