### PR TITLE
Quote Nix flake input URLs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,8 @@
   description = "A wrapper for ffmpeg and mp4v2 to merge, split, and manipulate audiobooks";
 
   inputs = {
-    nixpkgs.url = github:NixOS/nixpkgs/nixos-unstable;
-    flake-utils.url = github:numtide/flake-utils;
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs = { self, nixpkgs, flake-utils }:


### PR DESCRIPTION
URL literals are deprecated in Nix and require specifying the flag `--extra-deprecated-features url-literals` to use them. Quoting the URLs resolves this problem.